### PR TITLE
Correct typo in gpaw_output.py

### DIFF
--- a/src/gpaw_output.py
+++ b/src/gpaw_output.py
@@ -1,8 +1,6 @@
 # Note this file is taken from GPAW (file output.py).
 # This file is explicitly *not* published under the MIT licence,
-# but under the GPL version 3.0.
-
-, so is this file.
+# but under the GPL version 3.0--so is this file.
 
 import numpy as np
 

--- a/src/gpaw_output.py
+++ b/src/gpaw_output.py
@@ -1,6 +1,6 @@
 # Note this file is taken from GPAW (file output.py).
 # This file is explicitly *not* published under the MIT licence,
-# but under the GPL version 3.0--so is this file.
+# but under the GPL version 3.0.
 
 import numpy as np
 


### PR DESCRIPTION
Fixes a little typo (line near the top of the file should be commented out)