### PR TITLE
feat: add Makie based viz

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+PeriodicTable = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,10 @@ version = "0.1.2"
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 Bio3DView = "99c8bb3a-9d13-5280-9740-b4880ed9c598"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 

--- a/src/AtomsView.jl
+++ b/src/AtomsView.jl
@@ -3,6 +3,9 @@ using AtomsBase
 using Bio3DView
 using Unitful
 
+using Makie, GLMakie
+using Colors
+
 export visualize_structure
 
 
@@ -58,5 +61,8 @@ function visualize_structure(system::AbstractSystem, ::MIME"text/html";
 end
 
 # TODO Add visualize_structure functions for the "image/png" mime type
+
+include("viz.jl")
+export draw_system
 
 end

--- a/src/AtomsView.jl
+++ b/src/AtomsView.jl
@@ -5,6 +5,7 @@ using Unitful
 
 using Makie, GLMakie
 using Colors
+using PeriodicTable
 
 export visualize_structure
 

--- a/src/viz.jl
+++ b/src/viz.jl
@@ -1,0 +1,125 @@
+function draw_system(centers, r; bb_visible = true)
+    bb_o = Observable(bb_visible)
+
+    fig = Figure()
+    scene = Scene(camera = cam3d!, clear = false)
+    ax = Axis3(fig[1, 1], aspect = :data)
+    
+    cols = rand(keys(Colors.color_names), length(centers))
+    scs = []
+    alphas = []
+    for (center, color) in zip(centers, cols)
+        
+        alpha_o = Observable{Any}((color, 1))
+        sc = mesh!(ax, Sphere{Float32}(Point3f(center), r), color = alpha_o)
+        push!(scs, sc)
+        push!(alphas, alpha_o)
+
+
+        center_x = center[1]
+        center_y = center[2]
+        center_z = center[3]
+
+        xs = [center_x - r, center_x + r]
+        ys = [center_y - r, center_y + r]
+        zs = [center_z - r, center_z + r]
+
+        lines!(ax, [center_x - r], ys, [center_z - r], color = alpha_o, visible = bb_o)
+        lines!(ax, xs, [center_y - r], [center_z - r], color = alpha_o, visible = bb_o)
+        lines!(ax, [center_x - r], [center_y - r], zs, color = alpha_o, visible = bb_o)
+
+        lines!(ax, xs, [center_y - r], zs[2:2], color = alpha_o, visible = bb_o)
+        lines!(ax, [center_x - r], ys, zs[2:2], color = alpha_o, visible = bb_o)
+
+        lines!(ax, xs, ys[2:2], zs[2:2], color = alpha_o, visible = bb_o)
+        lines!(ax, xs[2:2], ys, [center_z - r], color = alpha_o, visible = bb_o)
+        lines!(ax, xs, ys[2:2], [center_z - r], color = alpha_o, visible = bb_o)
+        lines!(ax, xs[2:2], ys[2:2], zs, color = alpha_o, visible = bb_o)
+        lines!(ax, xs[2:2], ys, zs[2:2], color = alpha_o, visible = bb_o)
+
+        lines!(ax, xs[2:2], [center_y - r], zs, color = alpha_o, visible = bb_o)
+        lines!(ax, [center_x - r], ys[2:2], zs, color = alpha_o, visible = bb_o)
+    end
+
+    t_o = Observable("")
+
+    t = text!(ax, 10, 12, 15, text = t_o)
+    hotkey = Keyboard.a
+    on(events(fig).keyboardbutton) do event
+        if ispressed(fig, hotkey)
+            bb_o[] = !bb_o[]
+        end
+    end
+
+    on(events(fig).mousebutton, priority = 2) do event
+        if event.button == Mouse.left && event.action == Mouse.press
+            if Keyboard.d in events(fig).keyboardstate
+                t_o[] = string(mouseposition_px(ax))
+                return Consume(true)
+            end
+        end
+        return Consume(false)
+    end
+
+    global solid_idxs = []
+    on(events(fig).mousebutton, priority = 2) do event
+        if event.button == Mouse.left && event.action == Mouse.press
+            if Keyboard.s in events(fig).keyboardstate
+                plt, i = pick(fig)
+                idx = findall(x -> x == plt, scs)
+                if isempty(idx)
+                    return Consume(true)
+                end
+                if only(idx) in solid_idxs
+                    _idx = only(idx)
+                    alphas[_idx][] = (first(alphas[_idx][]), 0.3)
+                    _idx = findall(x -> x == only(idx), solid_idxs)
+                    deleteat!(solid_idxs, only(_idx))
+                    return Consume(true)
+                end
+                push!(solid_idxs, only(idx))
+                t_o[] = string(idx)
+                map(alphas) do o
+                    o[] = (first(o[]), 0.3)
+                end
+                map(alphas[solid_idxs]) do o
+                    o[] = (first(o[]), 1)
+                end
+                return Consume(true)
+            end
+        end
+        return Consume(false)
+    end
+    
+    
+    on(events(fig).keyboardbutton, priority = 3) do event
+        if ispressed(fig, Keyboard.r)
+            map(alphas) do o
+                o[] = (first(o[]), 1.)
+            end
+            solid_idxs = []
+            t_o[] = ""
+        end
+    end
+
+    # els = [MarkerElement(color = :black, marker = :circle, markersize = 15,) for i in 1:3]
+    # desc = [
+    #     "a: Toggle bounding box",
+    #     "s + Click: Select atom",
+    #     "d + Click: Get mouse position",
+    #     "r: Reset selection",
+    # ]
+    # Legend(fig[1,2], els, desc, "Things to do:",
+    #                     halign = :right,
+    #                     valign = :top,
+    #                     orientation = :vertical,
+    #                     tellheight = false,
+    #                     tellwidth = false,)
+    #                     # framecolor = grid_colour,
+    #                     # bgcolor = :transparent,
+    #                     # labelcolor = text_colour,
+    #                     # titlecolor = text_colour)
+
+
+    fig
+end

--- a/src/viz.jl
+++ b/src/viz.jl
@@ -1,11 +1,7 @@
-function draw_system(centers, r; bb_visible = true)
+function draw_system!(fig, ax, centers, r; colors = nothing, bb_visible = true)
     bb_o = Observable(bb_visible)
 
-    fig = Figure()
-    scene = Scene(camera = cam3d!, clear = false)
-    ax = Axis3(fig[1, 1], aspect = :data)
-    
-    cols = rand(keys(Colors.color_names), length(centers))
+    cols = colors
     scs = []
     alphas = []
     for (center, color) in zip(centers, cols)
@@ -122,4 +118,26 @@ function draw_system(centers, r; bb_visible = true)
 
 
     fig
+end
+
+function draw_system(system::AbstractSystem, r; colors = nothing, bb_visible = true)
+    positions = map(x -> map(y -> y.val, x), position(system))
+    cols = get_colors(system, colors)
+    fig = Figure()
+    ax = Axis3(fig[1, 1], aspect = :data)
+    draw_system!(fig, ax, positions, r; colors = cols, bb_visible = bb_visible)
+end
+
+function get_colors(system, colors::Nothing = nothing)
+    els = elements[atomic_symbol(system)]
+    map(x -> x.cpk_hex, els)
+end
+
+function get_colors(system, colors)
+    @assert length(system) == length(colors)
+    return colors
+end
+
+function get_colors(system, colors::Union{Symbol, String})
+    return fill(colors, length(system))
 end


### PR DESCRIPTION
During JuliaCon @mfherbst proposed the idea of replacing the current visualisation system with something more Julia based. We discussed the idea of using Makie.jl for this purpose since it allows some nice properties both in terms of customisation, simplicity and control.

This is the MWE towards fulfiling a visualisation element.

```julia
using Makie, GLMakie
using Colors
using AtomsView, AtomsBuilder, AtomsBase

system = bulk(:Cu) * (4,4,4)
positions = map(x -> map(y -> y.val, x), position(system))

draw_system(positions, 1.3)
```

The colours are currently randomised, but should be easy to replace. This is missing some metadata from the system currently that we might want to display. I wanted to open this now to get some the ball rolling. 

# Rendered in 3D space
<img width="600" alt="image" src="https://github.com/user-attachments/assets/d68c1f08-50ed-488f-8f52-60a3cc82c71f">

# With bounding boxes
<img width="599" alt="image" src="https://github.com/user-attachments/assets/9fa3b680-0bf1-4aec-a94c-c4c57e4ff3ab">

# Ability to select/ deselect some atoms
<img width="427" alt="image" src="https://github.com/user-attachments/assets/aae80b22-fdad-4e5e-8bfa-618896a537c7">

```
* "a: Toggle bounding box",
* "s + Click: Select atom",
* "d + Click: Get mouse position",
* "r: Reset selection",
```
